### PR TITLE
Pudni bloky dissolve

### DIFF
--- a/DSOeroze.py
+++ b/DSOeroze.py
@@ -89,7 +89,7 @@ class IsoTreelinesAlgo(QgsProcessingAlgorithm):
 
         self.addParameter(
             QgsProcessingParameterFolderDestination(
-                'mainfolder', 'Choose folder with scripts and outputdata destination',defaultValue=os.path.join('C:\\', 'Users', 'spravce', 'AppData', 'Roaming', 'QGIS', 'QGIS3', 'profiles', 'default', 'processing', 'scripts', 'water_project'), 
+                'mainfolder', 'Choose folder with scripts and outputdata destination',defaultValue=os.path.join('C:\\', 'Users', 'spravce', 'AppData', 'Roaming', 'QGIS', 'QGIS3', 'profiles', 'default', 'processing', 'scripts', 'anti-erosion-measures'), 
             )
             
         )
@@ -111,31 +111,50 @@ class IsoTreelinesAlgo(QgsProcessingAlgorithm):
         paths['tempfiles'] = qtool.createoutputpathdir(parameters['mainfolder'],'temp_files')
 
 
+        # Get the input raster layer
+        raster_layer = self.parameterAsRasterLayer(parameters, 'inputr', context)
 
+        extent = raster_layer.extent()
+        xmin = extent.xMinimum()
+        xmax = extent.xMaximum()
+        ymin = extent.yMinimum()
+        ymax = extent.yMaximum()
+        extent = '{},{},{},{}'.format(xmin, xmax, ymin, ymax)
+        print(extent)
 
         #create depresionless DEM
         results['depresionless_dem'] = qtool.filterDEM(parameters['inputr'],paths['tempfiles'])
+        print('depresionless_dem created')
 
         #calculate the watershed
         results['watershed'] = qtool.watershed(results['depresionless_dem'],paths['tempfiles'],parameters['watershedbasins']) 
+        print('watershed created')
 
         #cut the fields with the raster layer extent ""def clipfields(fields, raster, path_dict):""
-        results['clipedfields'] = qtool.clipfields(results['inputv'],parameters['inputr'],paths['tempfiles'])
+        results['clipedfields']= qtool.clipfields(parameters['inputv'],extent,paths['tempfiles'])
+        print('clipedfields created')
 
         #dissolve the fields ""def dissolvefields(fields, path_dict):""
         results['dissolvedfields'] = qtool.dissolvefields(results['clipedfields'],paths['tempfiles'])
+        print('dissolvedfields created')
 
         #cut the watershed with the field polygon ""def cutraster(raster,polygon,path_dict):""
         results['cuttedwatershed'] = qtool.cutraster(results['watershed'],results['dissolvedfields'],paths['tempfiles'])
+        print('cuttedwatershed created')
 
         #polygonize the raster 
         results['polygonizedwatershed'] = qtool.rastertopolygon(results['cuttedwatershed'],paths['tempfiles'])
+        print('polygonizedwatershed created')
 
         #polygon to line   
         results['linedpolygon'] = qtool.polygontoline(results['polygonizedwatershed'],paths['tempfiles'])
+        print('linedpolygon created')
 
         #buffer the DSO 
         results['bufferedlines'] = qtool.buffering(results['linedpolygon'],paths['tempfiles'])
+        print('bufferedlines created')
+        
+
 
         # Assuming 'results['bufferedlines']' is the path to your layer file
         layer = QgsVectorLayer(results['bufferedlines'][1], "grass_DSO", "ogr") # [1] is the second element in OUTPUT dictionary

--- a/qgis_tools.py
+++ b/qgis_tools.py
@@ -1,5 +1,6 @@
 from qgis.core import QgsProcessingAlgorithm
 from qgis.core import QgsApplication  # Add this line if QgsApplication is needed in your function
+from qgis.core import QgsRasterLayer
 from qgis.analysis import QgsNativeAlgorithms  # Add this line if needed
 from datetime import datetime
 
@@ -128,7 +129,7 @@ def filterDEM(raster, path_dict): #filter DEM from problem areas
     depresionlessDEM_output = depresionlessDEM['output']
     return depresionlessDEM_output
 
-def watershed(raster, path_dict, threshold1):
+def watershed(raster, path_dict, threshold1): #calculate watershed
     output_path = createoutputpathascii(path_dict,'watershed')
     watershed_raster = processing.run("grass7:r.watershed",\
                     {'elevation':raster,\
@@ -161,7 +162,7 @@ def watershed(raster, path_dict, threshold1):
     
     return watershed_raster['stream']
 
-def cutraster(raster,polygon,path_dict): 
+def cutraster(raster,polygon,path_dict):  #cut raster by polygon
     output_path = createoutputpathascii(path_dict,'cut_raster')
     cut_raster = processing.run("gdal:cliprasterbymasklayer",\
                     {'INPUT':raster,\
@@ -200,21 +201,19 @@ def polygontoline(polygons,path_dict): #convert polygon to line
 
     return polygon_to_line['OUTPUT']
 
-def clipfields(fields, raster, path_dict):
+def clipfields(fields, extent, path_dict): #extract layer part by extent
     output_path = createoutputpathascii(path_dict,'clip_fields')
 
-    # Calculate the extent of the raster layer
-    extent = raster.extent().toString()
     cliped_fields = processing.run("native:extractbyextent", {
         'INPUT': fields,
-        'EXTENT': extent,
+        'EXTENT':extent,
         'CLIP': False,
         'OUTPUT': os.path.join(output_path, 'output.shp')
     })
     return cliped_fields['OUTPUT']
 
 
-def dissolvefields(fields, path_dict):
+def dissolvefields(fields, path_dict): #dissolve layer polygons, because of the overlapping
     output_path = createoutputpathascii(path_dict,'dissolve_fields')
     dissolve = processing.run("native:dissolve", {
         'INPUT': fields,
@@ -223,4 +222,5 @@ def dissolvefields(fields, path_dict):
     })
 
     return dissolve['OUTPUT']
+
 

--- a/qgis_tools.py
+++ b/qgis_tools.py
@@ -200,3 +200,27 @@ def polygontoline(polygons,path_dict): #convert polygon to line
 
     return polygon_to_line['OUTPUT']
 
+def clipfields(fields, raster, path_dict):
+    output_path = createoutputpathascii(path_dict,'clip_fields')
+
+    # Calculate the extent of the raster layer
+    extent = raster.extent().toString()
+    cliped_fields = processing.run("native:extractbyextent", {
+        'INPUT': fields,
+        'EXTENT': extent,
+        'CLIP': False,
+        'OUTPUT': os.path.join(output_path, 'output.shp')
+    })
+    return cliped_fields['OUTPUT']
+
+
+def dissolvefields(fields, path_dict):
+    output_path = createoutputpathascii(path_dict,'dissolve_fields')
+    dissolve = processing.run("native:dissolve", {
+        'INPUT': fields,
+        'FIELD': [],
+        'OUTPUT': os.path.join(output_path, 'output.shp')
+    })
+
+    return dissolve['OUTPUT']
+


### PR DESCRIPTION
Přidáno ořezávání odtokových linií podle půdních bloků pro jejich následné zatravnění 

- polygony je třeba rozpustit, překrývající generují chybu 
- na LTR verzi 3.28 hlásí GDAL chybu a nelze ořezávat rastr podle rozsahu nebo polygonu, na 3.34 funguje 

